### PR TITLE
Add override continueUrl field to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Inne parametry - mają zastosowanie do wszystkich modułów:
 | --------- | ----
 | Domyślny status zamówienia | Status w jaki przejdzie zamówienie po rozpoczęciu płatności. Możliwe wartości to: `Wstrzymane (oczekujące na płatność) - on-hold` i `Oczekujące na płatność - pending`.<br />Zgodnie z dokomentacją WooCommerce w przypadku kontroli stanów magazynowych dla statusu `on-hold` nastąpi zmniejszenie ilości prduktów na magazynie oraz ich przywrócenie gdy zamówienie zmieni status na `canceled`, natomiast przy statusie `pending` stany magazynowe nie będę zmieniane. 
 | Włącz ponawianie płatności | Umożliwia płacącemu ponowienie nieudanej płatności. Przed włączeniem proszę o zapoznanie się z rozdziałem [Ponawianie płatności](#ponawianie-płatności).
+|Override continueUrl base | Umożliwia nadpisanie bazy adresu powrotu po przekierowaniu do bramki płatności. Adres ten zostanie rozszerzony o ID zamówienia z WooCommerce poprzez dodanie `/ID_ZAMÓWIENIA`. Użyteczne dla konfiguracji headless. Pozostawienie tego pola pustego powoduje powrót do domyślnej strony podsumowania zamówienia. |
 
 #### Konfiguracja metod płatności
 Parametry, które są dostępne dla każdej metody płatności:

--- a/includes/PayUSettings.php
+++ b/includes/PayUSettings.php
@@ -154,6 +154,23 @@ class PayUSettings
             'payu-settings-admin', // page
             'payu_settings_setting_section' // section
         );
+        add_settings_field(
+            'global_return_url', // id
+            __('Override continueUrl base', 'woo-payu-payment-gateway'), // title
+            [$this, 'global_return_url_callback'], // callback
+            'payu-settings-admin', // page
+            'payu_settings_setting_section' // section
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function global_return_url_callback()
+    {
+        $value = isset($this->payu_settings_options['global_return_url']) ? esc_url($this->payu_settings_options['global_return_url']) : '';
+        printf('<input type="text" class="regular-text" value="%s" name="payu_settings_option_name[global_return_url]" id="global_return_url" />',
+            $value);
     }
 
     /**
@@ -195,6 +212,11 @@ class PayUSettings
 
         if (isset($input['global_repayment'])) {
             $sanitary_values['global_repayment'] = sanitize_text_field($input['global_repayment']);
+        }
+
+        if (isset($input['global_return_url'])) {
+            $returnUrl = sanitize_text_field($input['global_return_url']);
+            $sanitary_values['global_return_url'] = rtrim($returnUrl, "/");
         }
 
         return $sanitary_values;

--- a/includes/WC_PayUGateways.php
+++ b/includes/WC_PayUGateways.php
@@ -719,10 +719,12 @@ abstract class WC_PayUGateways extends WC_Payment_Gateway
     function process_payment($order_id)
     {
         $order = wc_get_order($order_id);
+        $customContinue = get_option('payu_settings_option_name')['global_return_url'];
+        $continueUrl = $customContinue ? $customContinue.'/'.$order_id : $this->get_return_url($order);
         $this->init_OpenPayU();
         $billingData = $order->get_address();
         $orderData = [
-            'continueUrl' => $this->get_return_url($order),
+            'continueUrl' => $continueUrl,
             'notifyUrl' => add_query_arg('wc-api', $this->gateway_data('api'), home_url('/')),
             'customerIp' => $this->getIP(),
             'merchantPosId' => OpenPayU_Configuration::getMerchantPosId(),


### PR DESCRIPTION
Added `Override continueUrl base` field to global plugin configuration. Allows to manually replace base address of `continueUrl` field in order request body created by `process_payment`. Useful in configurations using headless checkout, e.g. via WooGraphQL.